### PR TITLE
Add live flight map inset

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ The firmware can be built and uploaded to the ESP32 using [PlatformIO](https://p
   - Edit `DISPLAY_BRIGHTNESS` in [UserConfiguration.h](firmware/config/UserConfiguration.h)
 - **Text color**: RGB values used for all text/borders
   - Edit `TEXT_COLOR_R`, `TEXT_COLOR_G`, `TEXT_COLOR_B` in [UserConfiguration.h](firmware/config/UserConfiguration.h)
+- **Map inset**: Shows the selected flight's live OpenSky position relative to your configured location and search radius
+  - Toggle `DISPLAY_MAP_ENABLED` and edit `MAP_MARKER_COLOR_R`, `MAP_MARKER_COLOR_G`, `MAP_MARKER_COLOR_B` in [UserConfiguration.h](firmware/config/UserConfiguration.h)
 
 We may add more customization options in the future, but of course this being open source the whole thing is customizable to your liking.
 

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -5,7 +5,7 @@ This is a high-level overview of the firmware that powers TheFlightWall on ESP32
 ### What it does
 - **Fetch nearby aircraft** from OpenSky Network using OAuth (states/all) filtered by location, radius, and bearing.
 - **Enrich flights** with readable airline/aircraft info from AeroAPI and TheFlightWall CDN.
-- **Render** a clean, minimal three-line flight card on a WS2812B LED matrix.
+- **Render** a clean, minimal flight card with a local map inset on a WS2812B LED matrix.
 
 ### Key components
 - **src/main.cpp**: Entry point. Initializes serial, Wi‑Fi, fetchers, and display. Periodically fetches/enriches and renders.
@@ -13,7 +13,7 @@ This is a high-level overview of the firmware that powers TheFlightWall on ESP32
 - **adapters/OpenSkyFetcher**: Queries OpenSky states/all with OAuth; parses and filters by geo.
 - **adapters/AeroAPIFetcher**: Retrieves flight details by ident via AeroAPI.
 - **adapters/FlightWallFetcher**: Looks up human‑friendly airline/aircraft names from CDN.
-- **adapters/NeoMatrixDisplay**: Draws bordered, centered three‑line flight card; cycles flights; shows loading.
+- **adapters/NeoMatrixDisplay**: Draws bordered, centered flight card with live map inset; cycles flights; shows loading.
 - **config/**: User/API/timing/hardware/Wi‑Fi settings.
 - **models/**: Lightweight structs for `StateVector`, `FlightInfo`, `AirportInfo`.
 - **utils/GeoUtils.h**: Haversine distance and bounding boxes.

--- a/firmware/adapters/NeoMatrixDisplay.cpp
+++ b/firmware/adapters/NeoMatrixDisplay.cpp
@@ -2,7 +2,7 @@
 Purpose: Render flight info on a WS2812B NeoPixel matrix via FastLED_NeoMatrix.
 Responsibilities:
 - Initialize LED matrix based on HardwareConfiguration and user display settings.
-- Render a bordered, three-line flight “card” and a minimal loading screen.
+- Render a bordered flight card with optional local map inset and a minimal loading screen.
 - Cycle through multiple flights at a configurable interval.
 Inputs: FlightInfo list; UserConfiguration (colors/brightness), TimingConfiguration (cycle),
         HardwareConfiguration (dimensions/pin/tiling).
@@ -13,6 +13,7 @@ Outputs: Visual output to LED matrix using FastLED.
 #include <Adafruit_GFX.h>
 #include <FastLED_NeoMatrix.h>
 #include <FastLED.h>
+#include <math.h>
 #include "config/UserConfiguration.h"
 #include "config/HardwareConfiguration.h"
 #include "config/TimingConfiguration.h"
@@ -121,6 +122,81 @@ String NeoMatrixDisplay::truncateToColumns(const String &text, int maxColumns)
     return text.substring(0, maxColumns - 3) + String("...");
 }
 
+bool NeoMatrixDisplay::shouldShowMapInset(const FlightInfo &f) const
+{
+    return UserConfiguration::DISPLAY_MAP_ENABLED &&
+           f.has_live_position &&
+           !isnan(f.distance_km) &&
+           !isnan(f.bearing_deg) &&
+           UserConfiguration::RADIUS_KM > 0.0 &&
+           _matrixWidth >= 96 &&
+           _matrixHeight >= 24;
+}
+
+void NeoMatrixDisplay::drawFlightMapInset(const FlightInfo &f, int16_t x, int16_t y, int16_t size, uint16_t mapColor)
+{
+    if (_matrix == nullptr || size < 12)
+        return;
+
+    const int16_t centerX = x + size / 2;
+    const int16_t centerY = y + size / 2;
+    const int16_t radius = (size / 2) - 3;
+    if (radius <= 2)
+        return;
+
+    _matrix->drawRect(x, y, size, size, mapColor);
+    _matrix->drawCircle(centerX, centerY, radius, mapColor);
+
+    // Center point is the configured home/location; the dot is the selected flight.
+    _matrix->drawLine(centerX - 1, centerY, centerX + 1, centerY, mapColor);
+    _matrix->drawLine(centerX, centerY - 1, centerX, centerY + 1, mapColor);
+    _matrix->drawPixel(centerX, y + 1, mapColor);
+
+    double distanceRatio = f.distance_km / UserConfiguration::RADIUS_KM;
+    if (distanceRatio < 0.0)
+    {
+        distanceRatio = 0.0;
+    }
+    if (distanceRatio > 1.0)
+    {
+        distanceRatio = 1.0;
+    }
+
+    const double bearingRad = f.bearing_deg * 3.14159265358979323846 / 180.0;
+    int16_t markerX = centerX + (int16_t)round(sin(bearingRad) * radius * distanceRatio);
+    int16_t markerY = centerY - (int16_t)round(cos(bearingRad) * radius * distanceRatio);
+    if (markerX < x + 2)
+        markerX = x + 2;
+    if (markerX > x + size - 3)
+        markerX = x + size - 3;
+    if (markerY < y + 2)
+        markerY = y + 2;
+    if (markerY > y + size - 3)
+        markerY = y + size - 3;
+
+    const uint16_t markerColor = _matrix->Color(UserConfiguration::MAP_MARKER_COLOR_R,
+                                                UserConfiguration::MAP_MARKER_COLOR_G,
+                                                UserConfiguration::MAP_MARKER_COLOR_B);
+
+    if (!isnan(f.heading_deg))
+    {
+        const double headingRad = f.heading_deg * 3.14159265358979323846 / 180.0;
+        int16_t headingX = markerX + (int16_t)round(sin(headingRad) * 4.0);
+        int16_t headingY = markerY - (int16_t)round(cos(headingRad) * 4.0);
+        if (headingX < x + 1)
+            headingX = x + 1;
+        if (headingX > x + size - 2)
+            headingX = x + size - 2;
+        if (headingY < y + 1)
+            headingY = y + 1;
+        if (headingY > y + size - 2)
+            headingY = y + size - 2;
+        _matrix->drawLine(markerX, markerY, headingX, headingY, markerColor);
+    }
+
+    _matrix->fillCircle(markerX, markerY, 2, markerColor);
+}
+
 void NeoMatrixDisplay::displaySingleFlightCard(const FlightInfo &f)
 {
     // Border
@@ -135,7 +211,12 @@ void NeoMatrixDisplay::displaySingleFlightCard(const FlightInfo &f)
     const int padding = 2;                                   // Small padding from border
     const int innerWidth = _matrixWidth - 2 - (2 * padding); // Account for border and padding
     const int innerHeight = _matrixHeight - 2 - (2 * padding);
-    const int maxCols = innerWidth / charWidth;
+    const bool showMap = shouldShowMapInset(f);
+    const int mapSize = showMap ? (innerHeight < 30 ? innerHeight : 30) : 0;
+    const int16_t mapX = _matrixWidth - 1 - padding - mapSize;
+    const int16_t mapY = 1 + padding + (innerHeight - mapSize) / 2;
+    const int textWidth = showMap ? (mapX - (1 + padding) - padding) : innerWidth;
+    const int maxCols = textWidth / charWidth;
 
     // Lines per display:
     // 1: airline
@@ -158,6 +239,11 @@ void NeoMatrixDisplay::displaySingleFlightCard(const FlightInfo &f)
     const uint16_t textColor = _matrix->Color(UserConfiguration::TEXT_COLOR_R,
                                               UserConfiguration::TEXT_COLOR_G,
                                               UserConfiguration::TEXT_COLOR_B);
+    if (showMap)
+    {
+        drawFlightMapInset(f, mapX, mapY, mapSize, textColor);
+    }
+
     const int lineCount = 3;
     const int lineSpacing = 1; // 1px spacing between lines
     const int totalTextHeight = lineCount * charHeight + (lineCount - 1) * lineSpacing;

--- a/firmware/adapters/NeoMatrixDisplay.h
+++ b/firmware/adapters/NeoMatrixDisplay.h
@@ -33,6 +33,8 @@ private:
     void drawTextLine(int16_t x, int16_t y, const String &text, uint16_t color);
     String makeFlightLine(const FlightInfo &f);
     String truncateToColumns(const String &text, int maxColumns);
+    bool shouldShowMapInset(const FlightInfo &f) const;
+    void drawFlightMapInset(const FlightInfo &f, int16_t x, int16_t y, int16_t size, uint16_t mapColor);
     void displaySingleFlightCard(const FlightInfo &f);
     void displayLoadingScreen();
 };

--- a/firmware/config/UserConfiguration.h
+++ b/firmware/config/UserConfiguration.h
@@ -17,4 +17,11 @@ namespace UserConfiguration
     static const uint8_t TEXT_COLOR_R = 255;
     static const uint8_t TEXT_COLOR_G = 255;
     static const uint8_t TEXT_COLOR_B = 255;
+
+    // Show a local map inset for the currently displayed flight.
+    // The map is centered on CENTER_LAT/CENTER_LON and scaled to RADIUS_KM.
+    static const bool DISPLAY_MAP_ENABLED = true;
+    static const uint8_t MAP_MARKER_COLOR_R = 0;
+    static const uint8_t MAP_MARKER_COLOR_G = 180;
+    static const uint8_t MAP_MARKER_COLOR_B = 255;
 }

--- a/firmware/core/FlightDataFetcher.cpp
+++ b/firmware/core/FlightDataFetcher.cpp
@@ -7,6 +7,9 @@ Flow:
 Output: Returns count of enriched flights and fills outStates/outFlights.
 */
 #include "core/FlightDataFetcher.h"
+
+#include <math.h>
+
 #include "config/UserConfiguration.h"
 #include "adapters/FlightWallFetcher.h"
 
@@ -38,6 +41,14 @@ size_t FlightDataFetcher::fetchFlights(std::vector<StateVector> &outStates,
         FlightInfo info;
         if (_flightFetcher->fetchFlightInfo(s.callsign, info))
         {
+            info.has_live_position = !isnan(s.lat) && !isnan(s.lon) &&
+                                     !isnan(s.distance_km) && !isnan(s.bearing_deg);
+            info.latitude = s.lat;
+            info.longitude = s.lon;
+            info.distance_km = s.distance_km;
+            info.bearing_deg = s.bearing_deg;
+            info.heading_deg = s.heading;
+
             FlightWallFetcher fw;
             if (info.operator_icao.length())
             {

--- a/firmware/core/FlightDataFetcher.cpp
+++ b/firmware/core/FlightDataFetcher.cpp
@@ -4,7 +4,7 @@ Flow:
 1) Use BaseStateVectorFetcher to fetch nearby state vectors by geo filter.
 2) For each callsign, use BaseFlightFetcher (e.g., AeroAPI) to retrieve FlightInfo.
 3) Enrich names via FlightWallFetcher (airline/aircraft display names).
-Output: Returns count of enriched flights and fills outStates/outFlights.
+Output: Returns fetch success, enriched flight count, and fills outStates/outFlights.
 */
 #include "core/FlightDataFetcher.h"
 
@@ -17,11 +17,13 @@ FlightDataFetcher::FlightDataFetcher(BaseStateVectorFetcher *stateFetcher,
                                      BaseFlightFetcher *flightFetcher)
     : _stateFetcher(stateFetcher), _flightFetcher(flightFetcher) {}
 
-size_t FlightDataFetcher::fetchFlights(std::vector<StateVector> &outStates,
-                                       std::vector<FlightInfo> &outFlights)
+bool FlightDataFetcher::fetchFlights(std::vector<StateVector> &outStates,
+                                     std::vector<FlightInfo> &outFlights,
+                                     size_t &outEnrichedCount)
 {
     outStates.clear();
     outFlights.clear();
+    outEnrichedCount = 0;
 
     bool ok = _stateFetcher->fetchStateVectors(
         UserConfiguration::CENTER_LAT,
@@ -29,8 +31,9 @@ size_t FlightDataFetcher::fetchFlights(std::vector<StateVector> &outStates,
         UserConfiguration::RADIUS_KM,
         outStates);
     if (!ok)
-        return 0;
+        return false;
 
+    size_t candidatesWithCallsign = 0;
     size_t enriched = 0;
     for (const StateVector &s : outStates)
     {
@@ -38,6 +41,8 @@ size_t FlightDataFetcher::fetchFlights(std::vector<StateVector> &outStates,
         {
             continue;
         }
+        candidatesWithCallsign++;
+
         FlightInfo info;
         if (_flightFetcher->fetchFlightInfo(s.callsign, info))
         {
@@ -73,5 +78,10 @@ size_t FlightDataFetcher::fetchFlights(std::vector<StateVector> &outStates,
             enriched++;
         }
     }
-    return enriched;
+    outEnrichedCount = enriched;
+    if (candidatesWithCallsign > 0 && enriched == 0)
+    {
+        return false;
+    }
+    return true;
 }

--- a/firmware/core/FlightDataFetcher.h
+++ b/firmware/core/FlightDataFetcher.h
@@ -13,8 +13,9 @@ public:
     FlightDataFetcher(BaseStateVectorFetcher *stateFetcher,
                       BaseFlightFetcher *flightFetcher);
 
-    size_t fetchFlights(std::vector<StateVector> &outStates,
-                        std::vector<FlightInfo> &outFlights);
+    bool fetchFlights(std::vector<StateVector> &outStates,
+                      std::vector<FlightInfo> &outFlights,
+                      size_t &outEnrichedCount);
 
 private:
     BaseStateVectorFetcher *_stateFetcher;

--- a/firmware/models/FlightInfo.h
+++ b/firmware/models/FlightInfo.h
@@ -23,6 +23,14 @@ struct FlightInfo
     // Aircraft
     String aircraft_code;
 
+    // Live position from the state vector used to enrich this flight
+    bool has_live_position = false;
+    double latitude = NAN;
+    double longitude = NAN;
+    double distance_km = NAN;
+    double bearing_deg = NAN;
+    double heading_deg = NAN;
+
     // Human-friendly display strings
     String airline_display_name_full;
     String aircraft_display_name_short;

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -26,7 +26,9 @@ static NeoMatrixDisplay g_display;
 static std::vector<FlightInfo> g_currentFlights;
 static unsigned long g_lastFetchMs = 0;
 static unsigned long g_lastDisplayMs = 0;
-static const unsigned long kDisplayRefreshMs = 100;
+static const unsigned long kDisplayRefreshMs = TimingConfiguration::DISPLAY_CYCLE_SECONDS > 0
+                                                   ? TimingConfiguration::DISPLAY_CYCLE_SECONDS * 1000UL
+                                                   : 1000UL;
 
 void setup()
 {
@@ -77,62 +79,75 @@ void loop()
         g_lastFetchMs = now;
 
         std::vector<StateVector> states;
-        size_t enriched = g_fetcher->fetchFlights(states, g_currentFlights);
+        std::vector<FlightInfo> nextFlights;
+        size_t enriched = 0;
+        const bool fetchOk = g_fetcher->fetchFlights(states, nextFlights, enriched);
 
-        Serial.print("OpenSky state vectors: ");
-        Serial.println((int)states.size());
-        Serial.print("AeroAPI enriched flights: ");
-        Serial.println((int)enriched);
-
-        for (const auto &s : states)
+        if (!fetchOk)
         {
-            Serial.print(" ");
-            Serial.print(s.callsign);
-            Serial.print(" @ ");
-            Serial.print(s.distance_km, 1);
-            Serial.print("km bearing ");
-            Serial.println(s.bearing_deg, 1);
+            Serial.print("Flight fetch failed; keeping cached flights: ");
+            Serial.println((int)g_currentFlights.size());
         }
-
-        for (const auto &f : g_currentFlights)
+        else
         {
-            Serial.println("=== FLIGHT INFO ===");
-            Serial.print("Ident: ");
-            Serial.println(f.ident);
-            Serial.print("Ident ICAO: ");
-            Serial.println(f.ident_icao);
-            Serial.print("Ident IATA: ");
-            Serial.println(f.ident_iata);
-            Serial.print("Airline: ");
-            Serial.println(f.airline_display_name_full);
-            Serial.print("Aircraft: ");
-            Serial.println(f.aircraft_display_name_short.length() ? f.aircraft_display_name_short : f.aircraft_code);
-            Serial.print("Operator Code: ");
-            Serial.println(f.operator_code);
-            Serial.print("Operator ICAO: ");
-            Serial.println(f.operator_icao);
-            Serial.print("Operator IATA: ");
-            Serial.println(f.operator_iata);
-            if (f.has_live_position)
+            g_currentFlights = nextFlights;
+            g_lastDisplayMs = 0;
+
+            Serial.print("OpenSky state vectors: ");
+            Serial.println((int)states.size());
+            Serial.print("AeroAPI enriched flights: ");
+            Serial.println((int)enriched);
+
+            for (const auto &s : states)
             {
-                Serial.print("Position: ");
-                Serial.print(f.latitude, 5);
-                Serial.print(", ");
-                Serial.print(f.longitude, 5);
-                Serial.print(" distance ");
-                Serial.print(f.distance_km, 1);
+                Serial.print(" ");
+                Serial.print(s.callsign);
+                Serial.print(" @ ");
+                Serial.print(s.distance_km, 1);
                 Serial.print("km bearing ");
-                Serial.println(f.bearing_deg, 1);
+                Serial.println(s.bearing_deg, 1);
             }
 
-            Serial.println("--- Origin ---");
-            Serial.print("Code ICAO: ");
-            Serial.println(f.origin.code_icao);
+            for (const auto &f : g_currentFlights)
+            {
+                Serial.println("=== FLIGHT INFO ===");
+                Serial.print("Ident: ");
+                Serial.println(f.ident);
+                Serial.print("Ident ICAO: ");
+                Serial.println(f.ident_icao);
+                Serial.print("Ident IATA: ");
+                Serial.println(f.ident_iata);
+                Serial.print("Airline: ");
+                Serial.println(f.airline_display_name_full);
+                Serial.print("Aircraft: ");
+                Serial.println(f.aircraft_display_name_short.length() ? f.aircraft_display_name_short : f.aircraft_code);
+                Serial.print("Operator Code: ");
+                Serial.println(f.operator_code);
+                Serial.print("Operator ICAO: ");
+                Serial.println(f.operator_icao);
+                Serial.print("Operator IATA: ");
+                Serial.println(f.operator_iata);
+                if (f.has_live_position)
+                {
+                    Serial.print("Position: ");
+                    Serial.print(f.latitude, 5);
+                    Serial.print(", ");
+                    Serial.print(f.longitude, 5);
+                    Serial.print(" distance ");
+                    Serial.print(f.distance_km, 1);
+                    Serial.print("km bearing ");
+                    Serial.println(f.bearing_deg, 1);
+                }
 
-            Serial.println("--- Destination ---");
-            Serial.print("Code ICAO: ");
-            Serial.println(f.destination.code_icao);
-            Serial.println("===================");
+                Serial.println("--- Origin ---");
+                Serial.print("Code ICAO: ");
+                Serial.println(f.origin.code_icao);
+
+                Serial.println("--- Destination ---");
+                Serial.print("Code ICAO: ");
+                Serial.println(f.destination.code_icao);
+                Serial.println("===================");
+            }
         }
     }
     const unsigned long displayNow = millis();

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -23,7 +23,10 @@ static AeroAPIFetcher g_aeroApi;
 static FlightDataFetcher *g_fetcher = nullptr;
 static NeoMatrixDisplay g_display;
 
+static std::vector<FlightInfo> g_currentFlights;
 static unsigned long g_lastFetchMs = 0;
+static unsigned long g_lastDisplayMs = 0;
+static const unsigned long kDisplayRefreshMs = 100;
 
 void setup()
 {
@@ -74,8 +77,7 @@ void loop()
         g_lastFetchMs = now;
 
         std::vector<StateVector> states;
-        std::vector<FlightInfo> flights;
-        size_t enriched = g_fetcher->fetchFlights(states, flights);
+        size_t enriched = g_fetcher->fetchFlights(states, g_currentFlights);
 
         Serial.print("OpenSky state vectors: ");
         Serial.println((int)states.size());
@@ -92,7 +94,7 @@ void loop()
             Serial.println(s.bearing_deg, 1);
         }
 
-        for (const auto &f : flights)
+        for (const auto &f : g_currentFlights)
         {
             Serial.println("=== FLIGHT INFO ===");
             Serial.print("Ident: ");
@@ -111,6 +113,17 @@ void loop()
             Serial.println(f.operator_icao);
             Serial.print("Operator IATA: ");
             Serial.println(f.operator_iata);
+            if (f.has_live_position)
+            {
+                Serial.print("Position: ");
+                Serial.print(f.latitude, 5);
+                Serial.print(", ");
+                Serial.print(f.longitude, 5);
+                Serial.print(" distance ");
+                Serial.print(f.distance_km, 1);
+                Serial.print("km bearing ");
+                Serial.println(f.bearing_deg, 1);
+            }
 
             Serial.println("--- Origin ---");
             Serial.print("Code ICAO: ");
@@ -121,8 +134,12 @@ void loop()
             Serial.println(f.destination.code_icao);
             Serial.println("===================");
         }
-
-        g_display.displayFlights(flights);
+    }
+    const unsigned long displayNow = millis();
+    if (displayNow - g_lastDisplayMs >= kDisplayRefreshMs)
+    {
+        g_lastDisplayMs = displayNow;
+        g_display.displayFlights(g_currentFlights);
     }
     delay(10);
 }


### PR DESCRIPTION
## Summary
- carry OpenSky live position data onto each enriched flight
- render a configurable local map inset for the currently rotated flight card
- cache the latest flights so display rotation continues between network fetches
- document the map toggle and marker color settings

## Validation
- /Users/ian/Library/Python/3.9/bin/pio run -d firmware

Note: the build still emits existing ArduinoJson deprecation warnings in the fetcher code.